### PR TITLE
install opensshd server, only allow public key login

### DIFF
--- a/roles/common-packages/tasks/main.yml
+++ b/roles/common-packages/tasks/main.yml
@@ -9,3 +9,4 @@
   with_items:
    - tig
    - curl
+   - tree

--- a/roles/ssh/handlers/main.yml
+++ b/roles/ssh/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: restart sshd
+  service:
+    name: ssh
+    state: reloaded
+  become: yes  

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -5,3 +5,17 @@
   openssh_keypair:
     type: rsa
     path: "{{  lookup('env', 'HOME') }}/.ssh/id_ssh_rsa"
+
+- name: Install OpenSSH server
+  package:
+    name: openssh-server
+    state: present
+  become: yes
+
+- name: sshd configuration
+  template:
+    src: sshd_config.j2
+    dest: /etc/ssh/sshd_config
+    mode: 0600
+  notify: restart sshd
+  become: yes

--- a/roles/ssh/templates/sshd_config.j2
+++ b/roles/ssh/templates/sshd_config.j2
@@ -1,0 +1,6 @@
+ChallengeResponseAuthentication no
+LogLevel VERBOSE
+PasswordAuthentication no
+PermitEmptyPasswords no
+PermitRootLogin no
+UsePAM no


### PR DESCRIPTION
Install `openssh-server` with `/etc/ssh/sshd_config` only allowing ssh through authorized keys and no password.
Piggyback `tree`